### PR TITLE
Show help if TTY and no args

### DIFF
--- a/bin/geotype.js
+++ b/bin/geotype.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(process.argv.slice(2),{boolean: ["p","png","nocolor","h","help"]});
 var fs = require('fs');
 var geotype = require('../');
 var concat = require('concat-stream');
 var savePixels = require("save-pixels");
 var zeros = require("zeros");
 
-if(argv.h || argv.help || !argv._.length){
+if(argv.h || argv.help || (!argv._.length && process.stdin.isTTY)){
   docs();
 }
 else {

--- a/bin/geotype.js
+++ b/bin/geotype.js
@@ -6,7 +6,7 @@ var concat = require('concat-stream');
 var savePixels = require("save-pixels");
 var zeros = require("zeros");
 
-if(argv.h || argv.help){
+if(argv.h || argv.help || !argv._.length){
   docs();
 }
 else {


### PR DESCRIPTION
Exceedingly minor, but if you were to run `geotype` without a file arg, it would hang and wait for a `stdin` stream that's never coming. This way it will show the docs instead. Also marked some boolean options so they can be specified before or after the input file.
